### PR TITLE
Add eslint spacing rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,3 +23,9 @@ rules:
     - never
   no-console:
     - off
+  comma-spacing:
+    - error
+  space-infix-ops:
+    - error
+  key-spacing:
+    - error

--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ const conn = mysql.createConnection({
     host: process.env.DB_HOST,
     user: process.env.DB_USER,
     password: process.env.DB_PASSWORD,
-    database : 'website_be',
+    database: 'website_be',
 })
 
 conn.connect((err) => {
     if (err) {
-        console.log('ERR: Could not connect to DB.')
+        console.log('ERR: Could not connect to DB. ' + err)
         return
     }
     console.log('Connnected to DB!')


### PR DESCRIPTION
## Some maintenance changes:
* Log the error when the DB fails to connect to make it easier to fix
* Add 3 eslint rules
  * Error on `const varName=3`, should be: `const varName = 3`
  * Error on `var1,var2`, should be: `var1, var2`
  * Error on `{ name:'Example' }`, should be: `{ name: 'Example' }`