### PR TITLE
Use the edit article endpoints to change published status

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,17 +15,9 @@ const mysqlOptions = process.env.CLEARDB_DATABASE_URL ? process.env.CLEARDB_DATA
     database: process.env.DB_NAME,
 }
 
-console.log(mysqlOptions)
-
-const conn = mysql.createConnection(mysqlOptions)
-
-conn.connect((err) => {
-    if (err) {
-        console.log('ERR: Could not connect to DB. ' + err)
-        return
-    }
-    console.log('Connnected to DB!')
-
+function start() {
+    // Creating a pool ensures the connection to the database is never lost
+    const conn = mysql.createPool(mysqlOptions)
     const app = express()
 
     app.use(cors())
@@ -35,7 +27,9 @@ conn.connect((err) => {
     app.use('/auth', authRouter)
     app.set('db', conn)
 
-    app.get('/', (req, res) => res.send('Not Found'))
+    app.get('/', (req, res) => res.send('Not Found'))    
 
     app.listen(port, () => console.log(`App listening on port ${port}!`))
-})
+}
+
+start()

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -46,11 +46,12 @@ router.post('/article/:id', requireAuth, (req, res) => {
             res.status(404)
             res.end()
         } else {
-            const { title, body, author, color } = results[0]
-            const { newTitle, newBody, newAuthor, newColor } = req.body
+            const { title, body, author, color, published } = results[0]
+            const { newTitle, newBody, newAuthor, newColor, newPublished } = req.body
+            const publishedVal = newPublished === 1 || newPublished === 0 ? newPublished : published
             db.query(
-                'UPDATE articles SET title = ?, body = ?, author = ?, color = ? WHERE id = ?'
-                , [newTitle || title, newBody || body, newAuthor || author, newColor || color, id]
+                'UPDATE articles SET title = ?, body = ?, author = ?, color = ?, published = ? WHERE id = ?'
+                , [newTitle || title, newBody || body, newAuthor || author, newColor || color, publishedVal, id]
                 , (error) => {
                     if (error) throw error
                     res.end()
@@ -87,24 +88,6 @@ router.post('/article/:id/liked', (req, res) => {
         if (error) throw error
         res.json()
     })
-})
-
-router.post('articles/:id/publish', (req, res) => {
-    const db = req.app.get('db')
-    const { id } = req.params
-    db.query('UPDATE articles SET isPublished = 1 WHERE id = ?', [id], (error => {
-        if(error) throw error
-        res.json()
-    }))
-})
-
-router.post('articles/:id/unpublish', (req, res) => {
-    const db = req.app.get('db')
-    const { id } = req.params
-    db.query('UPDATE articles SET isPublished = 0 WHERE id = ?', [id], (error => {
-        if(error) throw error
-        res.json()
-    }))
 })
 
 module.exports = router

--- a/schema.sql
+++ b/schema.sql
@@ -6,7 +6,8 @@ CREATE TABLE articles (
     likes       INT DEFAULT 0,
     views       INT DEFAULT 0,
     color       VARCHAR(20) DEFAULT "#5e9de6",
-    createdAt   TIMESTAMP DEFAULT NOW(), 
+    published   SMALLINT DEFAULT 0,
+    createdAt   TIMESTAMP DEFAULT NOW(),
     updatedAt   TIMESTAMP DEFAULT NOW() ON UPDATE NOW(),
     PRIMARY KEY (id)
 );


### PR DESCRIPTION
Closes https://github.com/mai-youth/website-fe/issues/69
* Enhanced the database connection
* Used the editArticle API for toggling publishes as well
* Updated schema

We have been affected by the use of `mysql.createConnection()` to connect to the database. This creates only one connection and the server goes down when that connection it closed. We got a lot of errors like this:
```
app[web.1]: Error: Connection lost: The server closed the connection.
app[web.1]: at Protocol.end (/app/node_modules/mysql/lib/protocol/Protocol.js:112:13)
app[web.1]: at Socket.<anonymous> (/app/node_modules/mysql/lib/Connection.js:97:28)
app[web.1]: at Socket.<anonymous> (/app/node_modules/mysql/lib/Connection.js:525:10)
app[web.1]: at Socket.emit (events.js:215:7)
app[web.1]: at endReadableNT (_stream_readable.js:1184:12)
app[web.1]: at processTicksAndRejections (internal/process/task_queues.js:80:21)
app[web.1]: Emitted 'error' event on Connection instance at:
app[web.1]: at Connection._handleProtocolError (/app/node_modules/mysql/lib/Connection.js:426:8)
app[web.1]: at Protocol.emit (events.js:210:5)
app[web.1]: at Protocol._delegateError (/app/node_modules/mysql/lib/protocol/Protocol.js:398:10)
app[web.1]: at Protocol.end (/app/node_modules/mysql/lib/protocol/Protocol.js:116:8)
app[web.1]: at Socket.<anonymous> (/app/node_modules/mysql/lib/Connection.js:97:28)
app[web.1]: [... lines matching original stack trace ...]
app[web.1]: at processTicksAndRejections (internal/process/task_queues.js:80:21) {
app[web.1]: fatal: true,
app[web.1]: code: 'PROTOCOL_CONNECTION_LOST'
app[web.1]: }
app[web.1]: [nodemon] app crashed - waiting for file changes before starting...
heroku[web.1]: State changed from up to down
```

Using a pool to connect instead creates a number of connections to the database and replaces the closed connections. I am now using `mysql.createPool()` to connect to the database.